### PR TITLE
Enables sSOSCF for CAHF

### DIFF
--- a/embed_sim/aodmet.py
+++ b/embed_sim/aodmet.py
@@ -92,13 +92,16 @@ class AODMET(ssdmet.SSDMET):
     """
     single-shot AO-DMET with impurity-environment partition
     """
-    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, es_natorb=True, bath_option=None, verbose=logger.INFO):
+    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, es_natorb=True, bath_option=None, verbose=logger.INFO, ncas=None, nelecas=None, spin=None):
         self.mf_or_cas = mf_or_cas
         self.mol = self.mf_or_cas.mol
         self.title = title
         self.max_mem = mf_or_cas.max_memory
         self.verbose = verbose
         self.log = lib.logger.new_logger(self.mol, self.verbose)
+        self.ncas = ncas
+        self.nelecas = nelecas
+        self.spin = spin
 
         # inputs
         self.dm = None
@@ -264,7 +267,10 @@ class AODMET(ssdmet.SSDMET):
             else:
                 pass
         
-        self.es_mf = self.ROHF()
+        if self.ncas is None:
+            self.es_mf = self.ROHF()
+        if self.ncas is not None:
+            self.es_mf = self.CAHF()
         self.fo_ene()
         self.log.info('')
         self.log.info(f'energy from frozen occupied orbitals = {self.fo_ene}')
@@ -293,4 +299,4 @@ class AODMET(ssdmet.SSDMET):
             else:
                 with_df = self.mf_or_cas.with_df
         return DFAODMET(self.mf_or_cas, self.title, imp_idx=self.imp_idx, threshold=self.threshold,
-                        with_df=with_df, es_natorb=self.es_natorb, bath_option=self.bath_option, verbose=self.verbose)
+                        with_df=with_df, es_natorb=self.es_natorb, bath_option=self.bath_option, verbose=self.verbose, ncas=self.ncas, nelecas=self.nelecas, spin=self.spin)

--- a/embed_sim/cahf.py
+++ b/embed_sim/cahf.py
@@ -146,7 +146,7 @@ def CAHF_get_occ(ncas, nelecas):
         mo_occ = np.zeros(len(mo_ea))
         mo_occ[:ncore] = 2
         mo_occ[ncore:ncore+ncas] = nelecas/ncas
-        print(mo_occ)
+        
         if mf.verbose >= logger.INFO and nocc < nmo and ncore > 0:
             ehomo = max(mo_energy[mo_occ> 0])
             elumo = min(mo_energy[mo_occ==0])

--- a/embed_sim/cahf.py
+++ b/embed_sim/cahf.py
@@ -142,11 +142,11 @@ def CAHF_get_occ(ncas, nelecas):
         nopen = nocc - ncore
         # mo_occ = _fill_rohf_occ(mo_energy, mo_ea, mo_eb, ncore, nopen)
 
-        ncore = int((np.sum(np.array(mf.mol.nelec))-nelecas)/2)
-        mo_occ = np.zeros(mf.mol.nao)
+        ncore = int((np.sum(np.array(nelec))-nelecas)/2)
+        mo_occ = np.zeros(len(mo_ea))
         mo_occ[:ncore] = 2
         mo_occ[ncore:ncore+ncas] = nelecas/ncas
-
+        print(mo_occ)
         if mf.verbose >= logger.INFO and nocc < nmo and ncore > 0:
             ehomo = max(mo_energy[mo_occ> 0])
             elumo = min(mo_energy[mo_occ==0])
@@ -409,7 +409,7 @@ class CAHF(scf.rohf.ROHF):
         return init_guess_by_chkfile(self.mol, chkfile, project=project)
     
     def gen_response(self, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None):
+                      with_j=True, hermi=0, max_memory=None,with_nlc=False):
         assert isinstance(self, CAHF)
         mol = self.mol
         f, a, b = self.frac, self.alpha, self.beta

--- a/embed_sim/df.py
+++ b/embed_sim/df.py
@@ -38,13 +38,14 @@ class DFSSDMET(ssdmet.SSDMET):
     """
     Density fitting single-shot DMET class
     """
-    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, with_df=None, es_natorb=True, bath_option=None, verbose=logger.INFO,ncas=None,nelecas=None,spin=None):
+    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, readmp2=readmp2, threshold=1e-12, with_df=None, es_natorb=True, bath_option=None, verbose=logger.INFO,ncas=None,nelecas=None,spin=None):
         self.mf_or_cas = mf_or_cas
         self.mol = self.mf_or_cas.mol
         self.title = title
         self.max_mem = mf_or_cas.max_memory # TODO
         self.verbose = verbose # TODO
         self.with_df = with_df
+        self.readmp2 = readmp2
         self.log = lib.logger.new_logger(self.mol, self.verbose)
         self.ncas = ncas
         self.nelecas = nelecas

--- a/embed_sim/df.py
+++ b/embed_sim/df.py
@@ -38,15 +38,17 @@ class DFSSDMET(ssdmet.SSDMET):
     """
     Density fitting single-shot DMET class
     """
-    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, with_df=None, es_natorb=True, readmp2 = False, bath_option=None, verbose=logger.INFO):
+    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, with_df=None, es_natorb=True, bath_option=None, verbose=logger.INFO,ncas=None,nelecas=None,spin=None):
         self.mf_or_cas = mf_or_cas
         self.mol = self.mf_or_cas.mol
         self.title = title
         self.max_mem = mf_or_cas.max_memory # TODO
-        self.readmp2 = readmp2
         self.verbose = verbose # TODO
         self.with_df = with_df
         self.log = lib.logger.new_logger(self.mol, self.verbose)
+        self.ncas = ncas
+        self.nelecas = nelecas
+        self.spin = spin
 
         # inputs
         self.dm = None
@@ -244,7 +246,10 @@ class DFSSDMET(ssdmet.SSDMET):
             else:
                 pass
 
-        self.es_mf = self.ROHF()
+        if ncas is None:
+            self.es_mf = self.ROHF()
+        if ncas is not None:
+            self.es_mf = self.CAHF()
         self.fo_ene()
         self.log.info('')
         self.log.info(f'energy from frozen occupied orbitals = {self.fo_ene}')
@@ -289,12 +294,43 @@ class DFSSDMET(ssdmet.SSDMET):
         es_mf.e_tot = es_mf.energy_tot()
         self.es_occ = es_mf.mo_occ
         return es_mf
-    
+    def CAHF(self):
+        mol = gto.M()
+        mol.verbose = self.verbose
+        mol.incore_anyway = True
+        mol.nelectron = self.mf_or_cas.mol.nelectron - 2*self.nfo
+        mol.spin = self.mol.spin
+
+        es_mf = cahf.CAHF(mol,ncas=self.ncas,nelecas=self.nelecas,spin=self.spin).x2c().density_fit()
+        es_mf.max_memory = self.max_mem
+        es_mf.mo_energy = np.zeros((self.nes))
+
+        es_ovlp = reduce(lib.dot, (self.es_orb.conj().T, self.mol.intor_symmetric('int1e_ovlp'), self.es_orb))
+        es_mf.get_hcore = lambda *args: self.es_int1e
+        es_mf.get_ovlp = lambda *args: es_ovlp
+        es_mf.with_df._cderi = self.es_cderi
+
+        # assume we only perfrom ROHF-in-ROHF embedding
+
+        # assert lib.einsum('ijj->', es_dm) == mol.nelectron
+        es_mf.level_shift = self.mf_or_cas.level_shift
+        es_mf.conv_check = False
+
+        es_fock = es_mf.get_fock(dm=self.es_dm)
+        mo_energy, mo_coeff = es_mf.eig(es_fock, es_ovlp)
+        mo_occ = es_mf.get_occ(mo_energy, mo_coeff)
+        es_mf.mo_energy = mo_energy
+        es_mf.mo_coeff = mo_coeff
+        es_mf.mo_occ = mo_occ
+        es_mf.e_tot = es_mf.energy_tot()
+        self.es_occ = es_mf.mo_occ
+        return es_mf
+
 class DFAODMET(aodmet.AODMET):
     """
     Density fitting single-shot AO-DMET class
     """
-    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, with_df=None, es_natorb=True, bath_option=None, verbose=logger.INFO):
+    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, with_df=None, es_natorb=True, bath_option=None, verbose=logger.INFO,ncas=None,nelecas=None,spin=None):
         self.mf_or_cas = mf_or_cas
         self.mol = self.mf_or_cas.mol
         self.title = title
@@ -302,6 +338,9 @@ class DFAODMET(aodmet.AODMET):
         self.verbose = verbose # TODO
         self.with_df = with_df
         self.log = lib.logger.new_logger(self.mol, self.verbose)
+        self.ncas = ncas
+        self.nelecas = nelecas
+        self.spin = spin
 
         # inputs
         self.dm = None
@@ -497,7 +536,10 @@ class DFAODMET(aodmet.AODMET):
             else:
                 pass
 
-        self.es_mf = self.ROHF()
+        if ncas is None:
+            self.es_mf = self.ROHF()
+        if ncas is not None:
+            self.es_mf = self.CAHF()
         self.fo_ene()
         self.log.info('')
         self.log.info(f'energy from frozen occupied orbitals = {self.fo_ene}')
@@ -519,6 +561,37 @@ class DFAODMET(aodmet.AODMET):
             es_mf = scf.ROHF(mol).x2c().density_fit()
         else:
             es_mf = scf.RHF(mol).x2c().density_fit()
+        es_mf.max_memory = self.max_mem
+        es_mf.mo_energy = np.zeros((self.nes))
+
+        es_ovlp = reduce(lib.dot, (self.es_orb.conj().T, self.mol.intor_symmetric('int1e_ovlp'), self.es_orb))
+        es_mf.get_hcore = lambda *args: self.es_int1e
+        es_mf.get_ovlp = lambda *args: es_ovlp
+        es_mf.with_df._cderi = self.es_cderi
+
+        # assume we only perfrom ROHF-in-ROHF embedding
+
+        # assert lib.einsum('ijj->', es_dm) == mol.nelectron
+        es_mf.level_shift = self.mf_or_cas.level_shift
+        es_mf.conv_check = False
+
+        es_fock = es_mf.get_fock(dm=self.es_dm)
+        mo_energy, mo_coeff = es_mf.eig(es_fock, es_ovlp)
+        mo_occ = es_mf.get_occ(mo_energy, mo_coeff)
+        es_mf.mo_energy = mo_energy
+        es_mf.mo_coeff = mo_coeff
+        es_mf.mo_occ = mo_occ
+        es_mf.e_tot = es_mf.energy_tot()
+        self.es_occ = es_mf.mo_occ
+        return es_mf
+    def CAHF(self):
+        mol = gto.M()
+        mol.verbose = self.verbose
+        mol.incore_anyway = True
+        mol.nelectron = self.mf_or_cas.mol.nelectron - 2*self.nfo
+        mol.spin = self.mol.spin
+
+        es_mf = cahf.CAHF(mol,ncas=self.ncas,nelecas=self.nelecas,spin=self.spin).x2c().density_fit()
         es_mf.max_memory = self.max_mem
         es_mf.mo_energy = np.zeros((self.nes))
 

--- a/embed_sim/ssdmet.py
+++ b/embed_sim/ssdmet.py
@@ -9,6 +9,7 @@ from pyscf import gto, scf, ao2mo
 from embed_sim.BNO_bath import get_RMP2_bath, get_UMP2_bath, get_ROMP2_bath
 from embed_sim import iao_helper
 from embed_sim import ic_helper
+from embed_sim import cahf
 
 import os
 
@@ -192,12 +193,15 @@ class SSDMET(lib.StreamObject):
     """
     single-shot DMET with impurity-environment partition
     """
-    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, es_natorb=True, readmp2 = False, bath_option=None, verbose=logger.INFO):
+    def __init__(self,mf_or_cas,title='untitled',imp_idx=None, threshold=1e-12, es_natorb=True, readmp2 = False, bath_option=None, verbose=logger.INFO, ncas=None, nelecas=None, spin=None):
         self.mf_or_cas = mf_or_cas
         self.mol = self.mf_or_cas.mol
         self.title = title
         self.max_mem = mf_or_cas.max_memory # TODO
         self.readmp2 = readmp2
+        self.ncas= ncas
+        self.nelecas = nelecas
+        self.spin = spin
         self.verbose = verbose # TODO
         self.log = lib.logger.new_logger(self.mol, self.verbose)
 
@@ -431,7 +435,10 @@ class SSDMET(lib.StreamObject):
             else:
                 pass
 
-        self.es_mf = self.ROHF()
+        if self.ncas is None:
+            self.es_mf = self.ROHF()
+        if self.ncas is not None:
+            self.es_mf = self.CAHF()
         self.fo_ene()
         self.log.info('')
         self.log.info(f'energy from frozen occupied orbitals = {self.fo_ene}')
@@ -501,7 +508,38 @@ class SSDMET(lib.StreamObject):
             es_mf.e_tot = es_mf.energy_tot()
             self.es_occ = es_mf.mo_occ
         return es_mf
-    
+    def CAHF(self):
+        mol = gto.M()
+        mol.verbose = self.verbose
+        mol.incore_anyway = True
+        mol.nelectron = self.mf_or_cas.mol.nelectron - 2*self.nfo
+        mol.spin = self.mol.spin
+        es_mf = cahf.CAHF(mol,ncas=self.ncas,nelecas=self.nelecas,spin=self.spin).x2c()
+        es_mf.max_memory = self.max_mem
+        es_mf.mo_energy = np.zeros((self.nes))
+
+        es_ovlp = reduce(lib.dot, (self.es_orb.conj().T, self.mol.intor_symmetric('int1e_ovlp'), self.es_orb))
+        es_mf.get_hcore = lambda *args: self.es_int1e
+        es_mf.get_ovlp = lambda *args: es_ovlp
+        es_mf._eri = self.es_int2e
+        es_mf.conv_check = False
+        if self.es_natorb:
+            es_mf.mo_coeff = np.eye(self.nes)
+            es_mf.mo_energy = np.zeros((self.nes))
+            es_mf.mo_occ = self.es_occ
+            es_mf.e_tot = es_mf.energy_tot(dm=self.es_dm)
+        else:
+            es_fock = es_mf.get_fock(dm=self.es_dm)
+            mo_energy, mo_coeff = es_mf.eig(es_fock, es_ovlp)
+            mo_occ = np.zeros(self.nes)
+            mo_occ = es_mf.get_occ(mo_energy, mo_coeff)
+            es_mf.mo_energy = mo_energy
+            es_mf.mo_coeff = mo_coeff
+            es_mf.mo_occ = mo_occ
+            es_mf.e_tot = es_mf.energy_tot()
+            self.es_occ = es_mf.mo_occ
+        return es_mf
+
     def avas(self, aolabels, *args, **kwargs):
         from embed_sim import myavas
         total_mf = self.total_mf()
@@ -559,4 +597,4 @@ class SSDMET(lib.StreamObject):
             else:
                 with_df = self.mf_or_cas.with_df
         return DFSSDMET(self.mf_or_cas, self.title, imp_idx=self.imp_idx, threshold=self.threshold,
-                        with_df=with_df, es_natorb=self.es_natorb, bath_option=self.bath_option, verbose=self.verbose)
+                        with_df=with_df, es_natorb=self.es_natorb, bath_option=self.bath_option, verbose=self.verbose,ncas=self.ncas,nelecas=self.nelecas,spin=self.spin)


### PR DESCRIPTION
Notice that in cahf.py, the with_nlc=False in gen_response is in line only with the latest version of PySCF